### PR TITLE
Add options for DigitalGlobe Standard and Premium

### DIFF
--- a/scanaerial.cfg
+++ b/scanaerial.cfg
@@ -21,6 +21,18 @@ fixedzoomlevel = 11
 #empty_tile_bytes = 2935
 #empty_tile_checksum = 839257317
 
+#server_api = tms
+#server_name = DigitalGlobe Standard
+#server_url = https://{switch:a,b,c}.tiles.mapbox.com/v4/digitalglobe.0a8e44ba/{zoom}/{x}/{y}.png?access_token=pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6ImNqM293Y3Y5ZjAwaWgycW55ZXFncHk0a3QifQ.6Kprj_J4oDmXqV97RricwA
+#empty_tile_bytes = 103
+#empty_tile_checksum = 1788459727
+
+#server_api = tms
+#server_name = DigitalGlobe Premium
+#server_url = https://{switch:a,b,c}.tiles.mapbox.com/v4/digitalglobe.316c9a2e/{zoom}/{x}/{y}.png?access_token=pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6ImNqM293YnJ5MTAwajIzMnF0bmV4dnV1MW4ifQ.psvzzOez33BOH8xmRiJZWg
+#empty_tile_bytes = 103
+#empty_tile_checksum = 1788459727
+
 server_api = bing
 server_name = Bing
 server_url = http://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?include=ImageryProviders&output=xml&key=Arzdiw4nlOJzRwOz__qailc8NiR31Tt51dN2D7cm57NrnceZnCpgOkmJhNpGoppU


### PR DESCRIPTION
Source of the configuration is the last post of [this thread](https://www.bountysource.com/issues/46915934-adding-of-digitalglobe-as-wms-sources).