### PR TITLE
Switch to Python 3

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
  - Scan for areas of similar colour on aerial pictures like OCR for text.
  - recognition works well with lakes, however it will not produce good results with
    wood in near future.
-   
+
 * Features/Changelog
 
 ** 2.1-beta-1
@@ -15,12 +15,12 @@
 
 ** 2.0-beta.1
  - TMS support added, new timeout check. Thanks to Vort
- 
+
 ** 1.0.3
  - malenki et al. reported that latlon.org does not work at the moment/anymore (?)
    geoposer.com is another bing WMS server, but somone has to figure out how to use it with scanaerial.
    Till then it is possible to use landsat with
-   wms_server_url = http://irs.gis-lab.info/?layers=landsat& 
+   wms_server_url = http://irs.gis-lab.info/?layers=landsat&
 
 ** 1.0.2
  - added tag source:zoomlevel. You see sometimes very different details
@@ -31,20 +31,20 @@
 
 ** 1.0.0
  - TMS Zoomlevel of JOSM is used for the downloaded WMS Tiles
- - scanaerial works with Ext_tools Plugin 
+ - scanaerial works with Ext_tools Plugin
 
 * Requirements
  - JOSM
  - Python. You can run library_check.py to find out if a library is missing
- - Ext_tools plug-in for JOSM. 
-   {TZoom} is part of Ext_tools since Ext_tools 25274 
+ - Ext_tools plug-in for JOSM.
+   {TZoom} is part of Ext_tools since Ext_tools 25274
  - Of course you need the scanaerial files too.
    You will find the latest releases on
    [[https://github.com/jonasstein/scanaerial/archives/master]]
    Copy them to JOSM/plugins/scanaerial for example.
 
 * Setup
- - unzip the contents of the downloaded archive to the JOSM plugin directory 
+ - unzip the contents of the downloaded archive to the JOSM plugin directory
    Linux users put it to: ~/.josm/plugins/ext_tools/scanaerial
  - start JOSM, press F12 and go to Ext_tools configuration
  - use this cmdline:/home/<username>/.josm/plugins/ext_tools/scanaerial/scanaerial.py {lat} {lon} {TZoom}
@@ -71,22 +71,22 @@
 * Roadmap
  - collect recipies for better algorithms
  - try to exclude douglas-peucker from scanaerial. josm can do that.
- - try different algorithms in forks and compare them. 
+ - try different algorithms in forks and compare them.
  - try to access cached wms tiles from josm
  - rewrite in c(++) and/or java
  - find betatester
 * Troubleshooting
- - if anything fails have a look on the error console. 
+ - if anything fails have a look on the error console.
    Scanaerial is very verbous.
 
 * Found a bug?
  - [[https://github.com/jonasstein/scanaerial/issues]]
- - if you want to contribute, please 
-   make a fork, 
+ - if you want to contribute, please
+   make a fork,
    make your changes in the fork
    do a pull request on this project site, or contact the author
 
-* Links 
+* Links
  - [[http://wiki.openstreetmap.org/wiki/Scanaerial][OSM Wiki about scanaerial]]
-   
+
 * Have fun!

--- a/canvas.py
+++ b/canvas.py
@@ -14,6 +14,13 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 if __name__ == "__main__":
     exit(0)
 
@@ -23,9 +30,9 @@ try:
     from urllib.error import URLError
     from urllib.error import HTTPError
 except ImportError:
-    from urllib2 import urlopen
-    from urllib2 import URLError
-    from urllib2 import HTTPError
+    from urllib.request import urlopen
+    from urllib.error import URLError
+    from urllib.error import HTTPError
 import io
 import datetime
 import sys
@@ -38,7 +45,7 @@ import projections
 
 time_str = {0:" first ", 1:" second ", 2:" third and last "}
 
-class WmsCanvas:
+class WmsCanvas(object):
 
     def __init__(self, server_url = None, server_api = None, proj = "EPSG:4326", zoom = 4, \
                  tile_size = None, mode = "RGBA", empty_tile_bytes = 0, empty_tile_checksum = 0):
@@ -195,7 +202,7 @@ class WmsCanvas:
         scale = 1.0
         if (self.server_api == "tms") or (self.server_api == "bing"):
             scale = 0.5
-        return projections.coords_by_tile(self.zoom, scale * x / self.tile_width, scale * y / self.tile_height, self.proj)
+        return projections.coords_by_tile(self.zoom, old_div(scale * x, self.tile_width), old_div(scale * y, self.tile_height), self.proj)
 
     def PixelFrom4326(self, lon, lat):
         scale = 1.0

--- a/canvas.py
+++ b/canvas.py
@@ -20,7 +20,6 @@ standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object
-from past.utils import old_div
 if __name__ == "__main__":
     exit(0)
 
@@ -202,7 +201,7 @@ class WmsCanvas(object):
         scale = 1.0
         if (self.server_api == "tms") or (self.server_api == "bing"):
             scale = 0.5
-        return projections.coords_by_tile(self.zoom, old_div(scale * x, self.tile_width), old_div(scale * y, self.tile_height), self.proj)
+        return projections.coords_by_tile(self.zoom, scale * x * 1.0 / self.tile_width, scale * y * 1.0 / self.tile_height, self.proj)
 
     def PixelFrom4326(self, lon, lat):
         scale = 1.0

--- a/canvas.py
+++ b/canvas.py
@@ -38,7 +38,7 @@ import datetime
 import sys
 import random
 import binascii
-from time import clock
+from time import process_time as clock
 from debug import debug
 #
 import projections

--- a/canvas.py
+++ b/canvas.py
@@ -119,21 +119,21 @@ class WmsCanvas(object):
     def ConstructQuadkey (self, tileX, tileY):
         """return Bing quadkey for given integer tile
         see (http://msdn.microsoft.com/en-us/library/bb259689.aspx)"""
-        
+
         tileX2 = self.baseN(tileX, 2)
         tileY2 = self.baseN(tileY, 2)
-        
+
         pad = self.zoom
-        
+
         tileX2 = "0"*(pad - len(tileX2)) + tileX2
         tileY2 = "0"*(pad - len(tileY2)) + tileY2
-        
+
         quadkey2 = ""
         for x in range(pad):
             quadkey2 = quadkey2 + tileY2[x] + tileX2[x]
-        
+
         quadkey = int(quadkey2, 2)
-        
+
         quadkey4 = self.baseN(quadkey, 4)
         quadkey4_pad = "0"*(pad - len(str(quadkey4))) + str(quadkey4)
 
@@ -154,7 +154,7 @@ class WmsCanvas(object):
             for dl_retrys in range(0, 3):
                 try:
                     contents = urlopen(remote).read()
-                    
+
                 except URLError as detail:
                     server_error = True
                     debug("error while fetching tile (" + str(x) + ", " + str(y) + ": " + str(detail))
@@ -183,7 +183,7 @@ class WmsCanvas(object):
                     continue
                 dl_done = True
                 break
-        
+
         if not dl_done:
             if server_error:
                 raise URLError(detail)
@@ -195,7 +195,7 @@ class WmsCanvas(object):
         self.tiles[(x, y)] = {}
         self.tiles[(x, y)]["im"] = tile_data
         self.tiles[(x, y)]["pix"] = tile_data.load()
-        
+
 
     def PixelAs4326(self, x, y):
         scale = 1.0

--- a/debug.py
+++ b/debug.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+from builtins import str
 if __name__ == "__main__":
     exit(0)
 

--- a/doc/README.ssm
+++ b/doc/README.ssm
@@ -34,15 +34,15 @@
 
   # Python ~{You can run library_check.py to find out if a library is missing}~
 
-  # Ext_tools plugin version >= 25274 for JOSM 
+  # Ext_tools plugin version >= 25274 for JOSM
 
-  # Of course you need the scanaerial files too. You will find the latest releases on 
+  # Of course you need the scanaerial files too. You will find the latest releases on
   { Github }https://github.com/jonasstein/scanaerial/archives/master Copy them to JOSM/plugins/scanaerial for example
 
 
 :B~ Setup
 
-  # unzip the contents of the downloaded archive to the JOSM Plugin directory 
+  # unzip the contents of the downloaded archive to the JOSM Plugin directory
    Linux Users put it to: .josm/plugins/ext_tools/scanaerial
 
   # In JOSM press F12 and go to Ext_tools configuration
@@ -56,34 +56,34 @@
 :B~ Configurationfile
 
 {table~h 30; 70;}
- key                     | function                                                
- fixedzoomlevel          | use this zoomlevel, if Ext_tools did not tell via TZoom 
- wmsname                 | name of the WMS Source (only for the tag string)        
- wms_server_url          | you may choose your favourite WMS server                
- projection              | projection that is used on the WMS server               
- tile_sizex,-y           | leave it to 256 unless you know what you do             
- douglas_peucker_epsilon | maximum roughness for smoothening the line              
- colour_str              | colour sensitivity                                      
- maxfilter_setting       | how many times should we apply the smoothening?         
+ key                     | function
+ fixedzoomlevel          | use this zoomlevel, if Ext_tools did not tell via TZoom
+ wmsname                 | name of the WMS Source (only for the tag string)
+ wms_server_url          | you may choose your favourite WMS server
+ projection              | projection that is used on the WMS server
+ tile_sizex,-y           | leave it to 256 unless you know what you do
+ douglas_peucker_epsilon | maximum roughness for smoothening the line
+ colour_str              | colour sensitivity
+ maxfilter_setting       | how many times should we apply the smoothening?
 
 
 
 :B~ Troubleshooting
 
- _* if anything fails have a look at the error console. 
+ _* if anything fails have a look at the error console.
     Scanaerial is very verbous.
 
 :B~ Found a bug?
 
  _* https://github.com/jonasstein/scanaerial/issues
 
- _* if you want to contribute, please 
-   make a fork, 
+ _* if you want to contribute, please
+   make a fork,
    make your changes in the fork
    do a pull request on this project site, or contact the author
 
-:B~ Links 
+:B~ Links
 
- _* OSM Wiki about scanaerial http://wiki.openstreetmap.org/wiki/Scanaerial 
-   
+ _* OSM Wiki about scanaerial http://wiki.openstreetmap.org/wiki/Scanaerial
+
 :B~ Have fun!

--- a/library_check.py
+++ b/library_check.py
@@ -43,5 +43,5 @@ except ImportError:
 
 if check:
     print("Everthing works fine, you may run scanaerial now.")
-    
+
 sleep(5)

--- a/library_check.py
+++ b/library_check.py
@@ -17,6 +17,7 @@
 """
 Use this to detect missing libaries which are needed by scanaerial.
 """
+from __future__ import print_function
 
 import sys
 from debug import debug

--- a/projections.py
+++ b/projections.py
@@ -15,7 +15,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 from __future__ import division
-from past.utils import old_div
 if __name__ == "__main__":
     exit(0)
 
@@ -65,7 +64,7 @@ def coords_by_tile(z, x, y, srs):
     Converts (z,x,y) to coordinates of corner of srs-projected tile
     """
     z -= 1
-    normalized_tile = (old_div(x, (2. ** z)), 1. - (old_div(y, (2. ** z))))
+    normalized_tile = (x * 1.0 / (2. ** z), 1. - (y * 1.0 / (2. ** z)))
     projected_bounds = from4326(projs[proj_alias.get(srs, srs)]["bounds"], srs)
     maxp = [projected_bounds[2] - projected_bounds[0], projected_bounds[3] - projected_bounds[1]]
     projected_coords = [(normalized_tile[0] * maxp[0]) + projected_bounds[0], (normalized_tile[1] * maxp[1]) + projected_bounds[1]]

--- a/projections.py
+++ b/projections.py
@@ -14,6 +14,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+from __future__ import division
+from past.utils import old_div
 if __name__ == "__main__":
     exit(0)
 
@@ -63,7 +65,7 @@ def coords_by_tile(z, x, y, srs):
     Converts (z,x,y) to coordinates of corner of srs-projected tile
     """
     z -= 1
-    normalized_tile = (x / (2. ** z), 1. - (y / (2. ** z)))
+    normalized_tile = (old_div(x, (2. ** z)), 1. - (old_div(y, (2. ** z))))
     projected_bounds = from4326(projs[proj_alias.get(srs, srs)]["bounds"], srs)
     maxp = [projected_bounds[2] - projected_bounds[0], projected_bounds[3] - projected_bounds[1]]
     projected_coords = [(normalized_tile[0] * maxp[0]) + projected_bounds[0], (normalized_tile[1] * maxp[1]) + projected_bounds[1]]

--- a/scanaerial.py
+++ b/scanaerial.py
@@ -24,7 +24,6 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
-from past.utils import old_div
 __author__ = "Darafei Praliaskouski, Jonas Stein, Ruben W., Vort"
 __license__ = "GPL"
 __credits__ = ["Lakewalker-developer-Team", "JOSM-developer-Team", "Malenki"]
@@ -286,7 +285,7 @@ for lin in outline:
     prx, pry = lin[-1]
 
     for x, y in lin:
-        area += old_div((x * pry - y * prx), 2)
+        area += (x * pry - y * prx) * 1.0 / 2
         prx = x
         pry = y
 

--- a/scanaerial.py
+++ b/scanaerial.py
@@ -37,7 +37,7 @@ try:
 except ImportError:
     import configparser as configparser
 import sys
-from time import clock
+from time import process_time as clock
 from sys import argv, stdout, setrecursionlimit
 from canvas import WmsCanvas
 from debug import debug

--- a/scanaerial.py
+++ b/scanaerial.py
@@ -322,7 +322,7 @@ debug("All done in: %s" % str(clock() - PROGRAM_START_TIMESTAMP))
 
 
 """ TODO
-* Zoomlevel to the source? May be soon there are higher resolutions and on different 
+* Zoomlevel to the source? May be soon there are higher resolutions and on different
   zoomlevels things look quite different
 
 """

--- a/scanaerial.py
+++ b/scanaerial.py
@@ -18,7 +18,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 This script will search an area with similar color and send
 it back to JOSM
 """
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from past.utils import old_div
 __author__ = "Darafei Praliaskouski, Jonas Stein, Ruben W., Vort"
 __license__ = "GPL"
 __credits__ = ["Lakewalker-developer-Team", "JOSM-developer-Team", "Malenki"]
@@ -29,7 +35,7 @@ __status__ = "Development"
 try:
     import configparser
 except ImportError:
-    import ConfigParser as configparser
+    import configparser as configparser
 import sys
 from time import clock
 from sys import argv, stdout, setrecursionlimit
@@ -119,7 +125,7 @@ TILE_SIZE = (config.getint('WMS', 'tile_sizex'),
 WAY_TAGS = {"source:tracer": "scanaerial",
             "source:zoomlevel": ZOOM,
             "source:position": SERVER_NAME}
-WAY_TAGS = dict(WAY_TAGS.items() + config.items('TAGS'))
+WAY_TAGS = dict(list(WAY_TAGS.items()) + config.items('TAGS'))
 
 POLYGON_TAGS = WAY_TAGS.copy()
 POLYGON_TAGS["type"] = "multipolygon"
@@ -280,7 +286,7 @@ for lin in outline:
     prx, pry = lin[-1]
 
     for x, y in lin:
-        area += (x * pry - y * prx) / 2
+        area += old_div((x * pry - y * prx), 2)
         prx = x
         pry = y
 
@@ -296,7 +302,7 @@ for lin in outline:
         stdout.write('<nd ref="%s" />' % (y))
     stdout.write('<nd ref="%s" />' % (node_num))
     if len(outline) == 1:
-        for z in WAY_TAGS.items():
+        for z in list(WAY_TAGS.items()):
             stdout.write(' <tag k="%s" v="%s" />"' % z)
     stdout.write("</way>")
 
@@ -306,7 +312,7 @@ if way_num < -1:
         role = ("inner", "outer")[int(roles[y])]
         stdout.write('<member type="way" ref="%s" role="%s" />' % (y, role))
 
-    for z in POLYGON_TAGS.items():
+    for z in list(POLYGON_TAGS.items()):
         stdout.write(' <tag k="%s" v="%s" />"' % z)
 
     stdout.write('</relation>')

--- a/scanaerial.py
+++ b/scanaerial.py
@@ -234,13 +234,13 @@ while normales_list:
         lin = [(x, y), ]
         popped = True
     found = False
-    if d is 0:  # up-pointing vector
+    if d == 0:  # up-pointing vector
         search = [(x + 0.5, y - 0.5, 3), (x + 1, y, 0), (x + 0.5, y + 0.5, 1)]
-    if d is 1:
+    if d == 1:
         search = [(x + 0.5, y + 0.5, 0), (x, y + 1, 1), (x - 0.5, y + 0.5, 2)]
-    if d is 2:
+    if d == 2:
         search = [(x - 0.5, y + 0.5, 1), (x - 1, y, 2), (x - 0.5, y - 0.5, 3)]
-    if d is 3:
+    if d == 3:
         search = [(x - 0.5, y - 0.5, 2), (x, y - 1, 3), (x + 0.5, y - 0.5, 0)]
     for kp in search:
         if kp in normales_list:

--- a/scanaerial_functions.py
+++ b/scanaerial_functions.py
@@ -18,7 +18,6 @@ from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
 from builtins import range
-from past.utils import old_div
 if __name__ == "__main__":
     exit(0)
 
@@ -48,9 +47,9 @@ def point_line_distance(point, startline, endline):
         return ((startline[0] - point[0]) ** 2 + \
                  (startline[1] - point[1]) ** 2) ** 0.5
     else:
-        return old_div(abs((endline[0] - startline[0]) * (startline[1] - point[1]) - \
-                     (startline[0] - point[0]) * (endline[1] - startline[1])), \
-                      ((endline[0] - startline[0]) ** 2 + (endline[1] - startline[1]) ** 2) ** 0.5)
+        return abs((endline[0] - startline[0]) * (startline[1] - point[1]) - \
+                     (startline[0] - point[0]) * (endline[1] - startline[1])) * 1.0 / \
+                      ((endline[0] - startline[0]) ** 2 + (endline[1] - startline[1]) ** 2) ** 0.5
                       
 def douglas_peucker(nodes, epsilon):
     """

--- a/scanaerial_functions.py
+++ b/scanaerial_functions.py
@@ -14,13 +14,18 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from past.utils import old_div
 if __name__ == "__main__":
     exit(0)
 
 try:
     from urllib.request import urlopen
 except ImportError:
-    from urllib2 import urlopen
+    from urllib.request import urlopen
 import xml.etree.ElementTree as ElementTree
 from sys import setrecursionlimit
 setrecursionlimit(1500000)    
@@ -43,9 +48,9 @@ def point_line_distance(point, startline, endline):
         return ((startline[0] - point[0]) ** 2 + \
                  (startline[1] - point[1]) ** 2) ** 0.5
     else:
-        return abs((endline[0] - startline[0]) * (startline[1] - point[1]) - \
-                     (startline[0] - point[0]) * (endline[1] - startline[1])) / \
-                      ((endline[0] - startline[0]) ** 2 + (endline[1] - startline[1]) ** 2) ** 0.5
+        return old_div(abs((endline[0] - startline[0]) * (startline[1] - point[1]) - \
+                     (startline[0] - point[0]) * (endline[1] - startline[1])), \
+                      ((endline[0] - startline[0]) ** 2 + (endline[1] - startline[1]) ** 2) ** 0.5)
                       
 def douglas_peucker(nodes, epsilon):
     """

--- a/scanaerial_functions.py
+++ b/scanaerial_functions.py
@@ -27,14 +27,14 @@ except ImportError:
     from urllib.request import urlopen
 import xml.etree.ElementTree as ElementTree
 from sys import setrecursionlimit
-setrecursionlimit(1500000)    
-    
+setrecursionlimit(1500000)
+
 def distance(a, b):
     """
     Euclidean metric
     """
     return  ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2) ** 0.5
-    
+
 def point_line_distance(point, startline, endline):
     """
     check if the "line" is actually a point
@@ -50,14 +50,14 @@ def point_line_distance(point, startline, endline):
         return abs((endline[0] - startline[0]) * (startline[1] - point[1]) - \
                      (startline[0] - point[0]) * (endline[1] - startline[1])) * 1.0 / \
                       ((endline[0] - startline[0]) ** 2 + (endline[1] - startline[1]) ** 2) ** 0.5
-                      
+
 def douglas_peucker(nodes, epsilon):
     """
     makes a linear curve smoother see also
     http://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
     Copypasted from lakewalker
     """
-    
+
     farthest_node = None
     farthest_dist = 0
     first = nodes[0]


### PR DESCRIPTION
In 2019 I used futurize script to make code running under Python 3, finally I made more commits to consider @jonasstein's [suggestion](https://github.com/jonasstein/scanaerial/issues/26) to use `x * 1.0 /` instead of `old_div` function. Also I replaced deprecated and deleted in Python 3.8 `time.clock()` with `time.process_time()` (for now in imports only).